### PR TITLE
Add Distance Sensor to Drivetrain and Command to Drive Straight with it

### DIFF
--- a/src/org/usfirst/frc/team2706/robot/OI.java
+++ b/src/org/usfirst/frc/team2706/robot/OI.java
@@ -19,7 +19,9 @@ public class OI {
 		
 	    public Joystick getDriverJoystick() {
 	        return driverStick;
-	    }	    public Joystick getOperatorJoystick() {
+	    }
+	    
+	    public Joystick getOperatorJoystick() {
 	        return controlStick;
 	    }
 	    
@@ -28,13 +30,13 @@ public class OI {
 			// Joystick for driving the robot around
 			driverStick = new Joystick(0);
 			
-			// Joystick for controlling the mechanisms of the robot
-			controlStick = new Joystick(1);
-			JoystickButton LB = new JoystickButton(driverStick,5);
-			
+			JoystickButton LB = new JoystickButton(driverStick, 5);	
 			// TODO: Tune stopCycles and speed
 			QuickStraightDriveWithDistanceSensor sdwe = new QuickStraightDriveWithDistanceSensor(0.5, 13.0, 15.0, 4, 0.8);
 			LB.whenPressed(sdwe);
+			
+			// Joystick for controlling the mechanisms of the robot
+			controlStick = new Joystick(1);
 	    }
 }
 

--- a/src/org/usfirst/frc/team2706/robot/OI.java
+++ b/src/org/usfirst/frc/team2706/robot/OI.java
@@ -33,7 +33,7 @@ public class OI {
 			JoystickButton LB = new JoystickButton(driverStick,5);
 			
 			// TODO: Tune stopCycles and speed
-			QuickStraightDriveWithDistanceSensor sdwe = new QuickStraightDriveWithDistanceSensor(0.5, 13.0, 15.0, 4);
+			QuickStraightDriveWithDistanceSensor sdwe = new QuickStraightDriveWithDistanceSensor(0.5, 13.0, 15.0, 4, 0.8);
 			LB.whenPressed(sdwe);
 	    }
 }

--- a/src/org/usfirst/frc/team2706/robot/OI.java
+++ b/src/org/usfirst/frc/team2706/robot/OI.java
@@ -1,6 +1,6 @@
 package org.usfirst.frc.team2706.robot;
 
-import org.usfirst.frc.team2706.robot.commands.autonomous.movements.StraightDriveWithEncoders;
+import org.usfirst.frc.team2706.robot.commands.autonomous.movements.QuickStraightDriveWithDistanceSensor;
 
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.buttons.JoystickButton;
@@ -31,7 +31,9 @@ public class OI {
 			// Joystick for controlling the mechanisms of the robot
 			controlStick = new Joystick(1);
 			JoystickButton LB = new JoystickButton(driverStick,5);
-			StraightDriveWithEncoders sdwe = new StraightDriveWithEncoders(0.75,-8/12.0,5,1);
+			
+			// TODO: Tune stopCycles and speed
+			QuickStraightDriveWithDistanceSensor sdwe = new QuickStraightDriveWithDistanceSensor(0.5, 13.0, 15.0, 4);
 			LB.whenPressed(sdwe);
 	    }
 }

--- a/src/org/usfirst/frc/team2706/robot/RobotMap.java
+++ b/src/org/usfirst/frc/team2706/robot/RobotMap.java
@@ -128,9 +128,14 @@ public class RobotMap {
 
     private static final int[] FLOAT_B_VALS = {0, 0, 0};
     public static final int FLOAT_B = getConstant("FLOAT_B");
-
-    // @TODO: Get Gyro channel, and rangefinder channel11
-
+    
+    
+    private static final int[] ULTRASONIC_PING_CHANNEL_VALS = {4, 4, 4};
+    public static final int ULTRASONIC_PING_CHANNEL = getConstant("ULTRASONIC_PING_CHANNEL");
+    
+    private static final int[] ULTRASONIC_ECHO_CHANNEL_VALS = {3, 3, 3};
+    public static final int ULTRASONIC_ECHO_CHANNEL = getConstant("ULTRASONIC_ECHO_CHANNEL");
+    
 
     private static final String ROBOT_ID_LOC = "/home/lvuser/robot-type.conf";
 

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/QuickStraightDriveWithDistanceSensor.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/QuickStraightDriveWithDistanceSensor.java
@@ -1,0 +1,95 @@
+package org.usfirst.frc.team2706.robot.commands.autonomous.movements;
+
+import org.usfirst.frc.team2706.robot.Robot;
+
+import edu.wpi.first.wpilibj.command.Command;
+
+/**
+ * Have the robot drive certain distance
+ */
+public class QuickStraightDriveWithDistanceSensor extends Command {
+    
+	private final double speed;
+	
+	private final double distance1;
+	private final double distance2;
+	
+	private boolean done;
+	private boolean forward;
+	
+	private int desiredStopCycles;
+	
+	private int stopCycles;
+	
+	/**
+	 * Drive at a specific speed for a certain amount of time
+	 * 
+	 * @param speed Speed in range [-1,1]
+	 * @param distance1 The min ultrasonic distance to travel in inches
+	 * @param distance2 The max ultrasonic distance to travel in inches
+	 * @param desiredStopCylces The amount of cycles the robot applies the reverse jolt or brakes
+	 */
+    public QuickStraightDriveWithDistanceSensor(double speed, double distance1, double distance2, int desiredStopCycles) {
+        requires(Robot.driveTrain);
+
+        this.speed = speed;
+        
+        this.distance1 = distance1;
+        this.distance2 = distance2;
+        
+        this.desiredStopCycles = desiredStopCycles;
+    }
+
+    // Called just before this Command runs the first time
+    protected void initialize() {
+    	Robot.driveTrain.reset();
+
+		Robot.driveTrain.initGyro = Robot.driveTrain.getHeading();
+		
+		done = false;
+		stopCycles = 0;
+    }
+
+    // Called repeatedly when this Command is scheduled to run
+    protected void execute() {  
+    	if(Robot.driveTrain.getDistanceToObstacle() > distance1
+    			&& Robot.driveTrain.getDistanceToObstacle() < distance2) {
+    		// TODO: Use CANTalons to do an actual break
+    		//		 instead of a jolt in the opposite direction
+    		if(stopCycles < desiredStopCycles) {
+    			double rotateVal = (Robot.driveTrain.normalize(Robot.driveTrain.getHeading() - Robot.driveTrain.initGyro) * 0.1);
+				Robot.driveTrain.arcadeDrive(forward ? speed : -speed, -rotateVal);
+				stopCycles++;
+    		}
+    		else
+    			done = true;
+    	}
+    	else if(Robot.driveTrain.getDistanceToObstacle() < distance1) {
+    		forward = true;
+    		double rotateVal = (Robot.driveTrain.normalize(Robot.driveTrain.getHeading() - Robot.driveTrain.initGyro) * 0.1);
+			Robot.driveTrain.arcadeDrive(-speed, -rotateVal);
+    	}
+    	else if(Robot.driveTrain.getDistanceToObstacle() > distance2) {
+    		forward = false;
+    		double rotateVal = (Robot.driveTrain.normalize(Robot.driveTrain.getHeading() - Robot.driveTrain.initGyro) * 0.1);
+			Robot.driveTrain.arcadeDrive(speed, -rotateVal);
+    	}
+    }
+    // Make this return true when this Command no longer needs to run execute()
+    protected boolean isFinished() {  
+    		return done;
+
+    }
+
+    // Called once after isFinished returns true
+    protected void end() {
+        Robot.driveTrain.drive(0, 0);
+    }
+
+    // Called when another command which requires one or more of the same
+    // subsystems is scheduled to run
+    protected void interrupted() {
+        end();
+    }
+}
+

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/QuickStraightDriveWithDistanceSensor.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/QuickStraightDriveWithDistanceSensor.java
@@ -3,7 +3,6 @@ package org.usfirst.frc.team2706.robot.commands.autonomous.movements;
 import org.usfirst.frc.team2706.robot.Robot;
 
 import edu.wpi.first.wpilibj.command.Command;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
  * Have the robot drive certain distance

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/QuickStraightDriveWithDistanceSensor.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/QuickStraightDriveWithDistanceSensor.java
@@ -69,7 +69,7 @@ public class QuickStraightDriveWithDistanceSensor extends Command {
     	
     	if(sensorAverage > distance1 && sensorAverage < distance2) {
     		// TODO: Use CANTalons to do an actual break
-    		//		 instead of a jolt in the opposite direction
+    		//       instead of a jolt in the opposite direction
     		if(stopCycles < desiredStopCycles) {
     			double rotateVal = (Robot.driveTrain.normalize(Robot.driveTrain.getHeading() - Robot.driveTrain.initGyro) * 0.1);
 				Robot.driveTrain.arcadeDrive(forward ? speed : -speed, -rotateVal);

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/QuickStraightDriveWithDistanceSensor.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/QuickStraightDriveWithDistanceSensor.java
@@ -56,16 +56,16 @@ public class QuickStraightDriveWithDistanceSensor extends Command {
 		done = false;
 		stopCycles = 0;
 		
-//    	SmartDashboard.putNumber("Smoothed Distance", 0);
-//    	SmartDashboard.putNumber("Distance Sensor", 0);
+		// SmartDashboard.putNumber("Smoothed Distance", 0);
+		// SmartDashboard.putNumber("Distance Sensor", 0);
     }
 
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {  
     	sensorAverage = alpha * Robot.driveTrain.getDistanceToObstacle() + (1 - alpha) * sensorAverage;
     	
-//    	SmartDashboard.putNumber("Smoothed Distance", sensorAverage);
-//    	SmartDashboard.putNumber("Distance Sensor", Robot.driveTrain.getDistanceToObstacle());
+    	// SmartDashboard.putNumber("Smoothed Distance", sensorAverage);
+    	// SmartDashboard.putNumber("Distance Sensor", Robot.driveTrain.getDistanceToObstacle());
     	
     	if(sensorAverage > distance1 && sensorAverage < distance2) {
     		// TODO: Use CANTalons to do an actual break

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/StraightDriveWithDistanceSensor.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/StraightDriveWithDistanceSensor.java
@@ -1,0 +1,140 @@
+package org.usfirst.frc.team2706.robot.commands.autonomous.movements;
+
+import org.usfirst.frc.team2706.robot.Robot;
+
+import edu.wpi.first.wpilibj.PIDController;
+import edu.wpi.first.wpilibj.command.Command;
+
+/**
+ * Have the robot drive certain distance
+ */
+public class StraightDriveWithDistanceSensor extends Command {
+    
+	private final double speed;
+	
+	private final double distance;
+	
+	private final int minDoneCycles;
+	
+	private final double error;
+	
+	private final PIDController leftPID;
+	private final PIDController rightPID;
+	
+	private int doneCount;
+	private final double P=1.0, I=0.03, D=0.5;
+	
+	/**
+	 * Drive at a specific speed for a certain amount of time
+	 * 
+	 * @param speed Speed in range [-1,1]
+	 * @param distance The ultrasonic distance to travel in inches
+	 * @param minDoneCycles The amount of cycles when the robot is within its target range to end the command
+	 * @param error The range that the robot is happy ending the command in
+	 */
+    public StraightDriveWithDistanceSensor(double speed, double distance, int minDoneCycles, double error) {
+        requires(Robot.driveTrain);
+
+        this.speed = speed;
+        
+        this.distance = distance;
+        
+        this.minDoneCycles = minDoneCycles;
+        
+        this.error = error;
+
+        leftPID = new PIDController(P,I,D,	 
+       		Robot.driveTrain.getDistanceSensorPIDSource(), 
+       		Robot.driveTrain.getDrivePIDOutput(false, true)
+        );
+        
+        rightPID = new PIDController(P,I,D,	 
+           	Robot.driveTrain.getDistanceSensorPIDSource(), 
+           	Robot.driveTrain.getDrivePIDOutput(false, false)
+        );
+    }
+
+    // Called just before this Command runs the first time
+    protected void initialize() {
+    	Robot.driveTrain.reset();
+    	
+    	// Make input infinite
+    	leftPID.setContinuous();
+    	rightPID.setContinuous();
+    	
+    	// Set output speed range
+    	if(speed > 0) {
+    		leftPID.setOutputRange(-speed, speed);
+    		rightPID.setOutputRange(-speed, speed);
+    	}
+    	else {
+    		leftPID.setOutputRange(speed, -speed);
+        	rightPID.setOutputRange(speed, -speed);
+    	}
+
+		Robot.driveTrain.initGyro = Robot.driveTrain.getHeading();
+		
+    	leftPID.setSetpoint(distance);
+    	rightPID.setSetpoint(distance);
+    	
+    	
+    	// Will accept within 5 inch of target
+    	leftPID.setAbsoluteTolerance(error);
+    	rightPID.setAbsoluteTolerance(error);
+    	
+    	// Start going to location
+    	leftPID.enable();
+    	//rightPID.enable();
+    }
+
+    // Called repeatedly when this Command is scheduled to run
+    protected void execute() {    	
+    	// TODO: Use WPI onTarget()
+    	onTarget();
+    }
+    // Make this return true when this Command no longer needs to run execute()
+    protected boolean isFinished() {  
+    	if(this.doneCount > this.minDoneCycles) {
+    		System.out.println("Command Ended!");
+    	
+    		return true;
+    	
+    	}
+    	else {
+    		return false;
+    	}
+
+    }
+
+    // Called once after isFinished returns true
+    protected void end() {
+    	doneCount = 0;
+    	// Disable PID output and stop robot to be safe
+    	leftPID.disable();
+    	rightPID.disable();
+        Robot.driveTrain.drive(0, 0);
+    }
+
+    // Called when another command which requires one or more of the same
+    // subsystems is scheduled to run
+    protected void interrupted() {
+        end();
+    }
+    
+    private boolean onTarget() {
+    	if(Math.abs(leftPID.getError()) < error && Math.abs(rightPID.getError()) < error) {
+    		doneCount++;
+    		return true;
+    	}
+    	else {
+    		doneCount = 0;
+    		return false;
+    	}
+    		
+    }
+    
+    public int getDoneCount() {
+    	return doneCount;
+    }
+}
+


### PR DESCRIPTION
It was determined that it would be easier to drive straight and stop when within a range given from the distance sensor than to use a PID loop. On the 2016 robot, we use Victor motors. Because of this, we cannot brake. To work around this, we make the motors jolt in the opposite direction for a certain amount of cycles. On the 2017 robot, we are planning on having CAN Talons, which support a brake mode, which would allow us to stop the robot instead. During testing of the ultrasonic sensor, we found that it reads accurately from a material that is similar to the material that would be found at competition, and found that it reads pretty accurately until the robot is more than 15 degrees from being perpendicular with the surface. If we do encounter outliers in the information, the command takes an alpha parameter which weights the distance input and previous average input to smooth out this noise. The command to move between 13 and 15 inches has not been fine tuned. When the command runs, it usually does not complete within the range given, but can be off by up to 4 inches, however this is likely due to the use of Victor motors, rather than CAN Talons.