### PR TITLE
Drive Practice Stuff

### DIFF
--- a/src/org/usfirst/frc/team2706/robot/bling/BlingPeriodic2.java
+++ b/src/org/usfirst/frc/team2706/robot/bling/BlingPeriodic2.java
@@ -77,7 +77,7 @@ public class BlingPeriodic2 extends Command {
              * 7 = Arms closed with no gear and peg in.
              */
             int gearState = Robot.gearHandler.gearHandlerState();
-            boolean climbing = Robot.climber.isClimbing();
+            boolean climbing = false;
             
             
             // This means we got a gear, and it's time to tell the drivers.
@@ -98,7 +98,7 @@ public class BlingPeriodic2 extends Command {
             
             // We are climbing!
             if (climbing) {
-                Robot.blingSystem.climbingDisplay();
+               Robot.blingSystem.climbingDisplay();
             }
             
             // Displaying peg line up
@@ -135,11 +135,6 @@ public class BlingPeriodic2 extends Command {
                 gearPickupHandler(gearState);
             }
             
-            
-            // Time to climb
-            else if (timeSinceInitialized() > 120) {
-                Robot.blingSystem.showReadyToClimb(true);
-            }
             
             // Show that we have a gear.
             else if (gearState == 1) {

--- a/src/org/usfirst/frc/team2706/robot/bling/BlingPeriodic2.java
+++ b/src/org/usfirst/frc/team2706/robot/bling/BlingPeriodic2.java
@@ -6,8 +6,6 @@ import org.usfirst.frc.team2706.robot.controls.StickRumble;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.command.Command;
-import edu.wpi.first.wpilibj.command.Scheduler;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /***
  * 
@@ -46,13 +44,7 @@ public class BlingPeriodic2 extends Command {
     protected static StickRumble rumbler = null; 
     
     protected static double previousGearState = 0;
-    
-    protected void initialize () {
-        if (DriverStation.getInstance().isAutonomous() && Robot.blingSystem.getSpecialState() == "autoTrue") {
-            Robot.blingSystem.auto();
-        }
-    }
-    
+       
     protected void execute () {
         
         double timePassed = Timer.getFPGATimestamp() - timePoint;
@@ -61,9 +53,6 @@ public class BlingPeriodic2 extends Command {
             return;
         
         timePoint = Timer.getFPGATimestamp();
-        
-        // Used to make sure we do not interrupt patterns with other patterns.
-        boolean busy = false;
         
         // Autonomous display modes
         if (DriverStation.getInstance().isAutonomous())
@@ -109,14 +98,12 @@ public class BlingPeriodic2 extends Command {
             
             // We are climbing!
             if (climbing) {
-                busy = true;
                 Robot.blingSystem.climbingDisplay();
             }
             
             // Displaying peg line up
             else  if (!gearPickupPattern && distance < outsideDistanceThreshold && ((1 <= gearState && gearState <= 3) || gearState == 5)) {
-                busy = true;
-                
+
                 // Get some vibration going, but only if there is already none.
                 if (2 <= gearState && gearState <= 3 && rumbler == null) {
                     rumbler = new StickRumble(0.7, 0.3, 2, 0.2, -1, 1.0, 0);
@@ -127,8 +114,7 @@ public class BlingPeriodic2 extends Command {
             }
             
             // Displaying pickup line up
-            else if ((distance < outsideDistanceThreshold) && (gearState == 0 || gearState == 4) && !busy) {
-                busy = true;
+            else if ((distance < outsideDistanceThreshold) && (gearState == 0 || gearState == 4)) {
                 
                 // Just right (arms closed and in nice distance)
                 if ((lowerDistanceThreshold <= distance) && (distance <= upperDistanceThreshold) && gearState == 0)
@@ -144,29 +130,27 @@ public class BlingPeriodic2 extends Command {
             }
             
             // Show that we just got a gear.
-            else if (gearPickupPattern && !busy) {
-                busy = true;
+            else if (gearPickupPattern) {
                 Robot.blingSystem.showGotGear();
                 gearPickupHandler(gearState);
             }
             
             
             // Time to climb
-            else if (timeSinceInitialized() > 120 && !busy) {
-                busy = true;
+            else if (timeSinceInitialized() > 120) {
                 Robot.blingSystem.showReadyToClimb(true);
             }
             
             // Show that we have a gear.
-            else if (gearState == 1 && !busy) {
-                busy = true;
+            else if (gearState == 1) {
                 Robot.blingSystem.funDisplay();                
             }
             
             // Show nothing.
-            else if (!busy) {
+            else {
                 Robot.blingSystem.clear();
             }
+            
             previousGearState = gearState;
         }
     }

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/TeleopStraightDriveWithCamera.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/movements/TeleopStraightDriveWithCamera.java
@@ -50,7 +50,7 @@ public class TeleopStraightDriveWithCamera extends Command {
             rotateVal = 0;
         }
         Log.d("TeleopStraightDriveWithCamera", "Rotattion Value: " + rotateVal);
-        Robot.driveTrain.arcadeDrive(-getTriggerValue() / 2, rotateVal);
+        Robot.driveTrain.arcadeDrive(-getTriggerValue() * 0.7, rotateVal);
     }
 
     private double getTriggerValue() {

--- a/src/org/usfirst/frc/team2706/robot/subsystems/Bling.java
+++ b/src/org/usfirst/frc/team2706/robot/subsystems/Bling.java
@@ -290,7 +290,7 @@ public class Bling extends Subsystem {
 
         // Peg in is true if the peg is going through the gear hole
         if (pegIn) {
-            dColour = "green";
+            dColour = "purple";
         }
         else {
             dColour = "red";

--- a/src/org/usfirst/frc/team2706/robot/subsystems/Climber.java
+++ b/src/org/usfirst/frc/team2706/robot/subsystems/Climber.java
@@ -18,7 +18,7 @@ public class Climber extends Subsystem {
     // Touchpad is 4ft 10in (1.4732 m) above the ground
 
     // Determines if the robot is climbing (to be verified)
-    private static final float I_KNOW_I_AM_CLIMBING_PITCH = 1.4f;
+    private static final float I_KNOW_I_AM_CLIMBING_PITCH = 45.0f;
 
     // Determines if the robot is not climbing (to be verified)
     private static final float I_KNOW_I_AM_FINISHED_CLIMBING_PITCH = 30.0f;

--- a/src/org/usfirst/frc/team2706/robot/subsystems/DriveTrain.java
+++ b/src/org/usfirst/frc/team2706/robot/subsystems/DriveTrain.java
@@ -169,8 +169,9 @@ public class DriveTrain extends Subsystem {
     public void drive(GenericHID joy) {
         double YAxis = RobotMap.INVERT_JOYSTICK_Y ? -joy.getRawAxis(5) : joy.getRawAxis(5);
         double XAxis = RobotMap.INVERT_JOYSTICK_X ? -joy.getRawAxis(4) : joy.getRawAxis(4);
-        if (joy.getRawButton(9)) {
+        if (joy.getRawButton(9) || joy.getRawButton(10)) {
             XAxis *= 0.7;
+            YAxis *= 0.7;
         }
         drive.arcadeDrive(YAxis, XAxis, true);
         


### PR DESCRIPTION
*All changes were tested during the drive practice, and were mere value
changes anyway*

- Tweaked one bling signal to display purple when the peg is in instead
of green.
- Just got rid of climbing bling signal completely, and the time to
climb one as well.
- Increased Vision speed from 50% to 70% when lining up for peg.
- Added the support for either of the triggers to be pressed inwards to
go into slow mode, and made slow mode affect forward and backwards as
well as the sides.